### PR TITLE
Fixed Zombie Team bug

### DIFF
--- a/src/GameServer.js
+++ b/src/GameServer.js
@@ -809,6 +809,7 @@ GameServer.prototype.getNearestVirus = function(cell) {
 
         // Add to list of cells nearby
         virus = check;
+        break; // stop checking when a virus found
     }
     return virus;
 };

--- a/src/gameserver.ini
+++ b/src/gameserver.ini
@@ -10,7 +10,7 @@
 // serverLogLevel: Logging level of the server. 0 = No logs, 1 = Logs the console, 2 = Logs console and ip connections
 serverMaxConnections = 64
 serverPort = 443
-serverGamemode = 13
+serverGamemode = 0
 serverBots = 0
 serverViewBaseX = 1024
 serverViewBaseY = 592

--- a/src/modules/CommandList.js
+++ b/src/modules/CommandList.js
@@ -261,7 +261,7 @@ Commands.list = {
                 }
                 nick = (nick == "") ? "An unnamed cell" : nick;
                 data = fillChar("SPECTATING: " + nick, '-', ' | CELLS | SCORE  | POSITION    '.length + gameServer.config.playerMaxNickLength, true);
-                console.log(""+id+" | "+ip+" | "+data);
+                console.log(" " + id + " | " + ip + " | " + data);
             } else if (client.cells.length > 0) {
                 nick = fillChar((client.name == "") ? "An unnamed cell" : client.name, ' ', gameServer.config.playerMaxNickLength);
                 cells = fillChar(client.cells.length, ' ', 5, true);
@@ -271,7 +271,7 @@ Commands.list = {
             } else { 
                 // No cells = dead player or in-menu
                 data = fillChar('DEAD OR NOT PLAYING', '-', ' | CELLS | SCORE  | POSITION    '.length + gameServer.config.playerMaxNickLength, true);
-                console.log(""+id+" | "+ip+" | "+data);
+                console.log(" " + id + " | " + ip + " | " + data);
             }
         }
     },


### PR DESCRIPTION
### Fix TeamZ mode
- [x] Crash when zombie eats Brain, then Virus.
- [x] Change mode with **gamemode** command. Warning: changing mode from 13 (TeamZ) to 1 (Teams) may cause error because `Teams.prototype.onServerInit` function does not handle well.
- [x] Revert config file to default mode (FFA).

### Fix global
- [x] Minor tweak **playerlist** command.
- [x] Minor improve `GameServer.prototype.getNearestVirus` function.
- [ ] Update **README.md** file and **gameserver.ini** (help text) for the new mode. Owner team, please help to update the document some time.