### PR TITLE
Experimental Team mode

### DIFF
--- a/src/gamemodes/TeamX.js
+++ b/src/gamemodes/TeamX.js
@@ -1,0 +1,307 @@
+var Teams = require('./Teams.js');
+var Cell = require('../entity/Cell.js');
+var Food = require('../entity/Food.js');
+var Virus = require('../entity/Virus.js');
+var VirusFeed = Virus.prototype.feed;
+
+var GS_getRandomColor = null; // backup getRandomColor function of current gameServer
+var GS_getRandomSpawn = null;
+
+function TeamX() {
+    Teams.apply(this, Array.prototype.slice.call(arguments));
+
+    this.ID = 14;
+    this.name = 'Experimental Team';
+
+    // configurations:
+    this.colorFuzziness = 64;
+    this.motherCellMass = 200;
+    this.motherUpdateInterval = 5; // How many ticks it takes to update the mother cell (1 tick = 50 ms)
+    this.motherSpawnInterval = 100; // How many ticks it takes to spawn another mother cell - Currently 5 seconds
+    this.motherMinAmount = 5;
+    
+    // game mode data:
+    this.colors = [
+        { 'r': 255, 'g': 7, 'b': 7 },
+        { 'r': 7, 'g': 255, 'b': 7 },
+        { 'r': 7, 'g': 7, 'b': 255 },
+    ];
+    this.nodesMother = [];
+    this.tickMother = 0;
+    this.tickMotherS = 0;
+}
+
+module.exports = TeamX;
+TeamX.prototype = new Teams();
+
+// Gamemode Specific Functions
+
+TeamX.prototype.updateMotherCells = function (gameServer) {
+    for (var i in this.nodesMother) {
+        var mother = this.nodesMother[i];
+        
+        // Checks
+        mother.update(gameServer);
+        mother.checkEat(gameServer);
+    }
+}
+
+TeamX.prototype.spawnMotherCell = function (gameServer) {
+    // Checks if there are enough mother cells on the map
+    if (this.nodesMother.length < this.motherMinAmount) {
+        // Spawns a mother cell
+        var pos = gameServer.getRandomPosition();
+        
+        // Check for players
+        for (var i = 0; i < gameServer.nodesPlayer.length; i++) {
+            var check = gameServer.nodesPlayer[i];
+            
+            var r = check.getSize(); // Radius of checking player cell
+            
+            // Collision box
+            var topY = check.position.y - r;
+            var bottomY = check.position.y + r;
+            var leftX = check.position.x - r;
+            var rightX = check.position.x + r;
+            
+            // Check for collisions
+            if (pos.y > bottomY) {
+                continue;
+            }
+            
+            if (pos.y < topY) {
+                continue;
+            }
+            
+            if (pos.x > rightX) {
+                continue;
+            }
+            
+            if (pos.x < leftX) {
+                continue;
+            }
+            
+            // Collided
+            return;
+        }
+        
+        // Spawn if no cells are colliding
+        var m = new MotherCell(gameServer.getNextNodeId(), null, pos, this.motherCellMass);
+        gameServer.addNode(m);
+    }
+};
+
+// Overwrite:
+
+TeamX.prototype.fuzzColorComponent = function (component) {
+    if (component != 255) {
+        component = Math.random() * (this.colorFuzziness - 7) + 7;
+    }
+    return component;
+};
+
+TeamX.prototype.getTeamColor = function (team) {
+    var color = this.colors[team];
+    return {
+        r: this.fuzzColorComponent(color.r),
+        b: this.fuzzColorComponent(color.b),
+        g: this.fuzzColorComponent(color.g)
+    };
+};
+
+TeamX.prototype.onServerInit = function (gameServer) {
+    // Set up teams
+    for (var i = 0; i < this.teamAmount; i++) {
+        this.nodes[i] = [];
+    }
+
+    // migrate current players to team mode
+    for (var i = 0; i < gameServer.clients.length; i++) {
+        var client = gameServer.clients[i].playerTracker;
+        this.onPlayerInit(client);
+        client.color = this.getTeamColor(client.team);
+        for (var j = 0; j < client.cells.length; j++) {
+            var cell = client.cells[j];
+            cell.setColor(client.color);
+            this.nodes[client.team].push(cell);
+        }
+    }
+
+    // Special virus mechanics
+    Virus.prototype.feed = function (feeder, gameServer) {
+        gameServer.removeNode(feeder);
+        // Pushes the virus
+        this.setAngle(feeder.getAngle()); // Set direction if the virus explodes
+        this.moveEngineTicks = 5; // Amount of times to loop the movement function
+        this.moveEngineSpeed = 30;
+        
+        var index = gameServer.movingNodes.indexOf(this);
+        if (index == -1) {
+            gameServer.movingNodes.push(this);
+        }
+    };
+    
+    if (GS_getRandomColor == null)
+        GS_getRandomColor = gameServer.getRandomColor; // backup
+    if (GS_getRandomSpawn == null)
+        GS_getRandomSpawn = gameServer.getRandomSpawn;
+    
+    // Override this
+    gameServer.getRandomSpawn = gameServer.getRandomPosition;
+    gameServer.getRandomColor = function () {
+        var colorRGB = [0xFF, 0x07, (Math.random() * 256) >> 0];
+        colorRGB.sort(function () { return 0.5 - Math.random() });
+        return {
+            r: colorRGB[0],
+            b: colorRGB[1],
+            g: colorRGB[2]
+        };
+    };
+};
+
+TeamX.prototype.onChange = function (gameServer) {
+    // Remove all mother cells
+    for (var i in this.nodesMother) {
+        gameServer.removeNode(this.nodesMother[i]);
+    }
+    // Add back default functions
+    Virus.prototype.feed = VirusFeed;
+    gameServer.getRandomColor = GS_getRandomColor;
+    gameServer.getRandomSpawn = GS_getRandomSpawn;
+    GS_getRandomColor = null;
+    GS_getRandomSpawn = null;
+};
+
+TeamX.prototype.onTick = function (gameServer) {
+    // Mother Cell updates
+    if (this.tickMother >= this.motherUpdateInterval) {
+        this.updateMotherCells(gameServer);
+        this.tickMother = 0;
+    } else {
+        this.tickMother++;
+    }
+    
+    // Mother Cell Spawning
+    if (this.tickMotherS >= this.motherSpawnInterval) {
+        this.spawnMotherCell(gameServer);
+        this.tickMotherS = 0;
+    } else {
+        this.tickMotherS++;
+    }
+};
+
+// New cell type (copied from Experimental mode)
+
+function MotherCell() { // Temporary - Will be in its own file if Zeach decides to add this to vanilla
+    Cell.apply(this, Array.prototype.slice.call(arguments));
+    
+    this.cellType = 2; // Copies virus cell
+    this.color = { r: 205, g: 85, b: 100 };
+    this.spiked = 1;
+}
+
+MotherCell.prototype = new Cell(); // Base
+
+MotherCell.prototype.getEatingRange = function () {
+    return this.getSize() * .5;
+};
+
+MotherCell.prototype.update = function (gameServer) {
+    // Add mass
+    this.mass += .25;
+    
+    // Spawn food
+    var maxFood = 10; // Max food spawned per tick
+    var i = 0; // Food spawn counter
+    while ((this.mass > gameServer.gameMode.motherCellMass) && (i < maxFood)) {
+        // Only spawn if food cap hasn been reached
+        if (gameServer.currentFood < gameServer.config.foodMaxAmount) {
+            this.spawnFood(gameServer);
+        }
+        
+        // Incrementers
+        this.mass--;
+        i++;
+    }
+}
+
+MotherCell.prototype.checkEat = function (gameServer) {
+    var safeMass = this.mass * .9;
+    var r = this.getSize(); // The box area that the checked cell needs to be in to be considered eaten
+    
+    // Loop for potential prey
+    for (var i in gameServer.nodesPlayer) {
+        var check = gameServer.nodesPlayer[i];
+        
+        if (check.mass > safeMass) {
+            // Too big to be consumed
+            continue;
+        }
+        
+        // Calculations
+        var len = r - (check.getSize() / 2) >> 0;
+        if ((this.abs(this.position.x - check.position.x) < len) && (this.abs(this.position.y - check.position.y) < len)) {
+            // Eats the cell
+            gameServer.removeNode(check);
+            this.mass += check.mass;
+        }
+    }
+    for (var i in gameServer.movingNodes) {
+        var check = gameServer.movingNodes[i];
+        
+        if ((check.getType() == 1) || (check.mass > safeMass)) {
+            // Too big to be consumed/ No player cells
+            continue;
+        }
+        
+        // Calculations
+        var len = r >> 0;
+        if ((this.abs(this.position.x - check.position.x) < len) && (this.abs(this.position.y - check.position.y) < len)) {
+            // Eat the cell
+            gameServer.removeNode(check);
+            this.mass += check.mass;
+        }
+    }
+}
+
+MotherCell.prototype.abs = function (n) {
+    // Because Math.abs is slow
+    return (n < 0) ? -n: n;
+}
+
+MotherCell.prototype.spawnFood = function (gameServer) {
+    // Get starting position
+    var angle = Math.random() * 6.28; // (Math.PI * 2) ??? Precision is not our greatest concern here
+    var r = this.getSize();
+    var pos = {
+        x: this.position.x + (r * Math.sin(angle)),
+        y: this.position.y + (r * Math.cos(angle))
+    };
+    
+    // Spawn food
+    var f = new Food(gameServer.getNextNodeId(), null, pos, gameServer.config.foodMass);
+    f.setColor(gameServer.getRandomColor());
+    
+    gameServer.addNode(f);
+    gameServer.currentFood++;
+    
+    // Move engine
+    f.angle = angle;
+    var dist = (Math.random() * 10) + 22; // Random distance
+    f.setMoveEngineData(dist, 15);
+    
+    gameServer.setAsMovingNode(f);
+};
+
+MotherCell.prototype.onConsume = Virus.prototype.onConsume; // Copies the virus prototype function
+
+MotherCell.prototype.onAdd = function (gameServer) {
+    gameServer.gameMode.nodesMother.push(this); // Temporary
+};
+
+MotherCell.prototype.onRemove = function (gameServer) {
+    var index = gameServer.gameMode.nodesMother.indexOf(this);
+    if (index != -1) {
+        gameServer.gameMode.nodesMother.splice(index, 1);
+    }
+};

--- a/src/gamemodes/TeamZ.js
+++ b/src/gamemodes/TeamZ.js
@@ -56,7 +56,7 @@ function TeamZ() {
     this.spawnHeroTimer = 0;
     this.spawnBrainTimer = 0;
 }
-1
+
 module.exports = TeamZ;
 TeamZ.prototype = new Mode();
 

--- a/src/gamemodes/Teams.js
+++ b/src/gamemodes/Teams.js
@@ -53,6 +53,18 @@ Teams.prototype.onServerInit = function(gameServer) {
     for (var i = 0; i < this.teamAmount; i++) {
         this.nodes[i] = [];
     }
+
+    // migrate current players to team mode
+    for (var i = 0; i < gameServer.clients.length; i++) {
+        var client = gameServer.clients[i].playerTracker;
+        this.onPlayerInit(client);
+        client.color = this.getTeamColor(client.team);
+        for (var j = 0; j < client.cells.length; j++) {
+            var cell = client.cells[j];
+            cell.setColor(client.color);
+            this.nodes[client.team].push(cell);
+        }
+    }
 };
 
 Teams.prototype.onPlayerInit = function(player) {

--- a/src/gamemodes/index.js
+++ b/src/gamemodes/index.js
@@ -8,7 +8,8 @@ module.exports = {
 	Rainbow: require('./Rainbow'),
     Debug: require('./Debug'),
     Zombie: require('./Zombie'),
-    TeamZ: require('./TeamZ.js')
+    TeamZ: require('./TeamZ.js'),
+    TeamX: require('./TeamX.js')
 };
 
 var get = function(id) {
@@ -31,6 +32,9 @@ var get = function(id) {
             break;
         case 13: // Zombie Team
             mode = new module.exports.TeamZ();
+            break;
+        case 14: // Experimental Team
+            mode = new module.exports.TeamX();
             break;
         case 20: // Rainbow
             mode = new module.exports.Rainbow();


### PR DESCRIPTION
# Experimental Team mode
Experimental Team mode is a game mode that combines **Teams** mode and **Experimental** mode. Especially, this mode allows fast feeding the teammate by splitting function.

This pull request also contains a bug fixed for changing game mode to Teams by command `gamemode 1`

### Mode info
* ID: 14
* Name: Experimental Team
* Code Name: TeamX

### New Entity
- **MOTHER**: MOTHER cell is a VIRUS cell which can consume smaller cells including Ejected Mass and Player cells. It spawns food around its location. (This entity is introduced in Experimental mode)

### Game rule
- Throwing mass at VIRUS cells (excluding MOTHER cells) will push them instead of making them split.
- Player cell can be consumed by its teammate unless it is the last cell of a player. This rule can be on/off toggle in the code (*TeamX.js*):
```javascript
 function TeamX() {
     Teams.apply(this, Array.prototype.slice.call(arguments));
 
     this.ID = 14;
     this.name = 'Experimental Team';
 
     // configurations:
    this.teamCollision = false; // set to true to disable eating teammates
```